### PR TITLE
Pull to provide more support to Pi 2 and Pi 3 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Requirements
 Installation
 ------------
 
+- if your Raspberry Pi is Raspberry Pi 2 Model B or NEWER, remove /src/gpio.hpp
+  file and rename /src/gpio.hpp.2 to /src/gpio.hpp
 - adjust Makefile to your needs. The standard Makefile should be fine if you're
   using g++.
 - run `make`

--- a/src/gpio.hpp.2
+++ b/src/gpio.hpp.2
@@ -1,0 +1,35 @@
+#ifndef FM_GPIO_HPP
+#define FM_GPIO_HPP
+
+#define BCM2708_PERI_BASE        0x3F000000
+#define GPIO_BASE                (BCM2708_PERI_BASE + 0x200000) /* GPIO controller */
+
+#define PAGE_SIZE (4*1024)
+#define BLOCK_SIZE (4*1024)
+
+extern int  mem_fd;
+extern void *gpio_map;
+
+// I/O access
+extern volatile unsigned *gpio;
+
+#ifndef NOGPIO
+// GPIO setup macros. Always use INP_GPIO(x) before using OUT_GPIO(x) or SET_GPIO_ALT(x,y)
+#define INP_GPIO(g) *(gpio+((g)/10)) &= ~(7<<(((g)%10)*3))
+#define OUT_GPIO(g) *(gpio+((g)/10)) |=  (1<<(((g)%10)*3))
+#define SET_GPIO_ALT(g,a) *(gpio+(((g)/10))) |= (((a)<=3?(a)+4:(a)==4?3:2)<<(((g)%10)*3))
+#define GET_GPIO(g) (*(gpio+13)&(1<<g)) // 0 if LOW, (1<<g) if HIGH
+#else
+#define INP_GPIO(g)
+#define OUT_GPIO(g)
+#define SET_GPIO_ALT(g)
+#define GET_GPIO(g) 0
+#endif
+
+#define GPIO_SET *(gpio+7)  // sets   bits which are 1 ignores bits which are 0
+#define GPIO_CLR *(gpio+10) // clears bits which are 1 ignores bits which are 0
+
+
+void setup_io();
+
+#endif


### PR DESCRIPTION
Related to https://github.com/Kingdread/floppymusic/issues/1
I created a file gpio.hpp.2 with the right address for RPi 2 and 3 models, and explained in the readme under "installation" that in case you own one of the new models you have to delete gpio.hpp and rename gpio.hpp.2 to gpio.hpp
